### PR TITLE
Remove dangling map tag.

### DIFF
--- a/maps/rheumatoid_man_map.html
+++ b/maps/rheumatoid_man_map.html
@@ -1,79 +1,78 @@
 <!-- Rheumatoid Man -->
-    <area data-key="f01" title="Left Temporomandibular" href="" shape="circle" coords="228,59,8" />
-    <area data-key="f02" title="Right Temporomandibular" href="" shape="circle" coords="178,60,8" />
-    <area data-key="f03" title="Left Sternoclavicular" href="" shape="circle" coords="215,114,9" />
-    <area data-key="f04" title="Right Sternoclavicular" href="" shape="circle" coords="189,113,7" />
-    <area data-key="f05" title="Left Acromioclavicular" href="" shape="circle" coords="247,106,9" />
-    <area data-key="f06" title="Right Acromioclavicular" href="" shape="circle" coords="157,107,8" />
-    <area data-key="f07" title="Left Shoulder" href="" shape="circle" coords="267,128,19" />
-    <area data-key="f08" title="Right Shoulder" href="" shape="circle" coords="138,127,19" />
-    <area data-key="f09" title="Left Elbow" href="" shape="circle" coords="282,208,19" />
-    <area data-key="f10" title="Right Elbow" href="" shape="circle" coords="122,208,20" />
-    <area data-key="f11" title="Left Wrist" href="" shape="circle" coords="312,281,18" />
-    <area data-key="f12" title="Right Wrist" href="" shape="circle" coords="92,280,21" />
-    <area data-key="f13" title="Left Thumb Carpometacarpal " href="" shape="circle" coords="343,281,7" />
-    <area data-key="f14" title="Right Thumb Carpometacarpal " href="" shape="circle" coords="61,282,8" />
-    <area data-key="f15" title="Left Thumb Metacarpal" href="" shape="circle" coords="356,305,9" />
-    <area data-key="f16" title="Right Thumb Metacarpal" href="" shape="circle" coords="47,306,7" />
-    <area data-key="f17" title="Left Thumb Interphalangeal" href="" shape="circle" coords="379,324,6" />
-    <area data-key="f18" title="Right Thumb Interphalangeal" href="" shape="circle" coords="25,324,8" />
-    <area data-key="f19" title="Left Index MCP" href="" shape="circle" coords="348,322,8" />
-    <area data-key="f20" title="Left Index PIP" href="" shape="circle" coords="363,350,8" />
-    <area data-key="f21" title="Left Index DIP" href=""  shape="circle"coords="372,374,9" />
-    <area data-key="f22" title="Left Middle MCP" href="" shape="circle" coords="331,328,7" />
-    <area data-key="f23" title="Left Middle PIP" href="" shape="circle" coords="341,360,8" />
-    <area data-key="f24" title="Left Middle DIP" href="" shape="circle" coords="351,388,8" />
-    <area data-key="f25" title="Left Ring MCP" href="" shape="circle" coords="311,331,7" />
-    <area data-key="f26" title="Left Ring PIP" href="" shape="circle" coords="316,363,7" />
-    <area data-key="f27" title="Left Ring DIP" href="" shape="circle" coords="321,391,8" />
-    <area data-key="f28" title="Left Pinky MCP" href="" shape="circle" coords="294,331,7" />
-    <area data-key="f29" title="Left Pinky PIP" href="" shape="circle" coords="292,357,8" />
-    <area data-key="f30" title="Left Pinky DIP" href="" shape="circle" coords="296,383,8" />
-    <area data-key="f31" title="Right Index MCP" href="" shape="circle" coords="57,321,8" />
-    <area data-key="f32" title="Right Index PIP" href="" shape="circle" coords="42,350,6" />
-    <area data-key="f33" title="Right Index DIP" href="" shape="circle" coords="34,375,8" />
-    <area data-key="f34" title="Right Middle MCP" href="" shape="circle" coords="73,327,8" />
-    <area data-key="f35" title="Right Middle PIP" href="" shape="circle" coords="64,361,8" />
-    <area data-key="f36" title="Right Middle DIP" href="" shape="circle" coords="53,388,8" />
-    <area data-key="f37" title="Right Ring MCP" href="" shape="circle" coords="93,331,7" />
-    <area data-key="f38" title="Right Ring PIP" href="" shape="circle" coords="88,365,8" />
-    <area data-key="f39" title="Right Ring DIP" href="" shape="circle" coords="83,388,7" />
-    <area data-key="f40" title="Right Pinky MCP" href="" shape="circle" coords="108,328,8" />
-    <area data-key="f41" title="Right Pinky PIP" href="" shape="circle" coords="110,355,8" />
-    <area data-key="f42" title="Right Pinky DIP" href="" shape="circle" coords="109,382,9" />
-    <area data-key="f43" title="Left Hip" href="" shape="circle" coords="240,303,20" />
-    <area data-key="f44" title="Right Hip" href="" shape="circle" coords="165,304,19" />
-    <area data-key="f45" title="Left Knee" href="" shape="circle" coords="236,444,18" />
-    <area data-key="f46" title="Right Knee" href="" shape="circle" coords="168,443,19" />
-    <area data-key="f47" title="Left Hallux MTP" href="" shape="circle" coords="221,621,9" />
-    <area data-key="f48" title="Left Hallux PIP" href="" shape="circle" coords="226,639,8" />
-    <area data-key="f49" title="Left Index Toe MTP " href="" shape="circle" coords="242,619,9" />
-    <area data-key="f50" title="Left Index Toe PIP" href="" shape="circle" coords="247,637,8" />
-    <area data-key="f51" title="Left Middle Toe MTP" href="" shape="circle" coords="264,617,9" />
-    <area data-key="f52" title="Left Middle Toe PIP" href="" shape="circle" coords="268,637,8" />
-    <area data-key="f53" title="Left Ring Toe MTP" href="" shape="circle" coords="283,609,8" />
-    <area data-key="f54" title="Left Ring Toe PIP" href="" shape="circle" coords="287,628,9" />
-    <area data-key="f55" title="Left Pinky Toe MTP" href="" shape="circle" coords="301,599,9" />
-    <area data-key="f56" title="Left Pinky Toe PIP" href="" shape="circle" coords="305,617,7" />
-    <area data-key="f57" title="Right Hallux MTP" href="" shape="circle" coords="183,621,8" />
-    <area data-key="f58" title="Right Hallux PIP" href="" shape="circle" coords="178,640,10" />
-    <area data-key="f59" title="Right Index Toe MTP" href="" shape="circle" coords="161,620,8" />
-    <area data-key="f60" title="Right Index Toe PIP" href="" shape="circle" coords="157,638,9" />
-    <area data-key="f61" title="Right Middle Toe MTP" href="" shape="circle" coords="140,617,8" />
-    <area data-key="f62" title="Right Middle Toe PIP" href="" shape="circle" coords="136,636,7" />
-    <area data-key="f63" title="Right Ring Toe MTP" href="" shape="circle" coords="121,609,9" />
-    <area data-key="f64" title="Right Ring Toe PIP" href="" shape="circle" coords="117,629,9" />
-    <area data-key="f65" title="Right Pinky Toe MTP" href="" shape="circle" coords="102,598,8" />
-    <area data-key="f66" title="Right Pinky Toe PIP" href="" shape="circle" coords="99,619,9" />
-    <area data-key="f67" title="Cervical Spine" href="" shape="poly" coords="193,79,209,79,211,108,206,112,206,118,199,117,197,110,193,106" />
-    <area data-key="f68" title="Thoracic Spine" href="" shape="poly" coords="193,126,197,118,208,119,212,126,211,202,202,200,192,203" />
-    <area data-key="f69" title="Lumbar Spine" href="" shape="poly" coords="194,201,202,199,211,200,211,260,202,263,194,262" />
-    <area data-key="f70" title="Left Sacroiliac" href="" shape="circle" coords="221,268,9" />
-    <area data-key="f71" title="Right Sacroiliac" href="" shape="circle" coords="182,268,9" />
-    <area data-key="f72" title="Left Ankle" href="" shape="poly" coords="242,553,250,552,256,554,261,558,261,565,256,568,250,569,242,571,234,570,226,566,223,561,228,554,236,549" />
-    <area data-key="f73" title="Right Ankle" href="" shape="poly" coords="159,553,168,553,179,558,180,567,173,571,164,574,156,574,147,571,142,566,143,558,149,554" />
-    <area data-key="f74" title="Left Talonavicular" href="" shape="poly" coords="218,589,226,581,240,576,255,571,274,570,285,572,282,580,271,586,261,590,242,595,227,594" />
-    <area data-key="f75" title="Right Talonavicular" href="" shape="poly" coords="119,575,130,571,141,572,153,575,171,580,183,587,186,594,175,595,159,596,145,593,131,588,124,584" />
-    <area data-key="f76" title="Left Tarsometatarsal" href="" shape="poly" coords="219,607,237,599,257,593,278,587,294,585,291,593,280,600,264,605,249,608,234,610" />
-    <area data-key="f77" title="Right Tarsometatarsal" href="" shape="poly" coords="110,584,124,586,135,587,148,591,162,597,174,601,182,604,188,605,174,609,160,610,147,608,133,604,124,600,116,594" />
-</map>
+<area data-key="f01" title="Left Temporomandibular" href="" shape="circle" coords="228,59,8" />
+<area data-key="f02" title="Right Temporomandibular" href="" shape="circle" coords="178,60,8" />
+<area data-key="f03" title="Left Sternoclavicular" href="" shape="circle" coords="215,114,9" />
+<area data-key="f04" title="Right Sternoclavicular" href="" shape="circle" coords="189,113,7" />
+<area data-key="f05" title="Left Acromioclavicular" href="" shape="circle" coords="247,106,9" />
+<area data-key="f06" title="Right Acromioclavicular" href="" shape="circle" coords="157,107,8" />
+<area data-key="f07" title="Left Shoulder" href="" shape="circle" coords="267,128,19" />
+<area data-key="f08" title="Right Shoulder" href="" shape="circle" coords="138,127,19" />
+<area data-key="f09" title="Left Elbow" href="" shape="circle" coords="282,208,19" />
+<area data-key="f10" title="Right Elbow" href="" shape="circle" coords="122,208,20" />
+<area data-key="f11" title="Left Wrist" href="" shape="circle" coords="312,281,18" />
+<area data-key="f12" title="Right Wrist" href="" shape="circle" coords="92,280,21" />
+<area data-key="f13" title="Left Thumb Carpometacarpal " href="" shape="circle" coords="343,281,7" />
+<area data-key="f14" title="Right Thumb Carpometacarpal " href="" shape="circle" coords="61,282,8" />
+<area data-key="f15" title="Left Thumb Metacarpal" href="" shape="circle" coords="356,305,9" />
+<area data-key="f16" title="Right Thumb Metacarpal" href="" shape="circle" coords="47,306,7" />
+<area data-key="f17" title="Left Thumb Interphalangeal" href="" shape="circle" coords="379,324,6" />
+<area data-key="f18" title="Right Thumb Interphalangeal" href="" shape="circle" coords="25,324,8" />
+<area data-key="f19" title="Left Index MCP" href="" shape="circle" coords="348,322,8" />
+<area data-key="f20" title="Left Index PIP" href="" shape="circle" coords="363,350,8" />
+<area data-key="f21" title="Left Index DIP" href=""  shape="circle"coords="372,374,9" />
+<area data-key="f22" title="Left Middle MCP" href="" shape="circle" coords="331,328,7" />
+<area data-key="f23" title="Left Middle PIP" href="" shape="circle" coords="341,360,8" />
+<area data-key="f24" title="Left Middle DIP" href="" shape="circle" coords="351,388,8" />
+<area data-key="f25" title="Left Ring MCP" href="" shape="circle" coords="311,331,7" />
+<area data-key="f26" title="Left Ring PIP" href="" shape="circle" coords="316,363,7" />
+<area data-key="f27" title="Left Ring DIP" href="" shape="circle" coords="321,391,8" />
+<area data-key="f28" title="Left Pinky MCP" href="" shape="circle" coords="294,331,7" />
+<area data-key="f29" title="Left Pinky PIP" href="" shape="circle" coords="292,357,8" />
+<area data-key="f30" title="Left Pinky DIP" href="" shape="circle" coords="296,383,8" />
+<area data-key="f31" title="Right Index MCP" href="" shape="circle" coords="57,321,8" />
+<area data-key="f32" title="Right Index PIP" href="" shape="circle" coords="42,350,6" />
+<area data-key="f33" title="Right Index DIP" href="" shape="circle" coords="34,375,8" />
+<area data-key="f34" title="Right Middle MCP" href="" shape="circle" coords="73,327,8" />
+<area data-key="f35" title="Right Middle PIP" href="" shape="circle" coords="64,361,8" />
+<area data-key="f36" title="Right Middle DIP" href="" shape="circle" coords="53,388,8" />
+<area data-key="f37" title="Right Ring MCP" href="" shape="circle" coords="93,331,7" />
+<area data-key="f38" title="Right Ring PIP" href="" shape="circle" coords="88,365,8" />
+<area data-key="f39" title="Right Ring DIP" href="" shape="circle" coords="83,388,7" />
+<area data-key="f40" title="Right Pinky MCP" href="" shape="circle" coords="108,328,8" />
+<area data-key="f41" title="Right Pinky PIP" href="" shape="circle" coords="110,355,8" />
+<area data-key="f42" title="Right Pinky DIP" href="" shape="circle" coords="109,382,9" />
+<area data-key="f43" title="Left Hip" href="" shape="circle" coords="240,303,20" />
+<area data-key="f44" title="Right Hip" href="" shape="circle" coords="165,304,19" />
+<area data-key="f45" title="Left Knee" href="" shape="circle" coords="236,444,18" />
+<area data-key="f46" title="Right Knee" href="" shape="circle" coords="168,443,19" />
+<area data-key="f47" title="Left Hallux MTP" href="" shape="circle" coords="221,621,9" />
+<area data-key="f48" title="Left Hallux PIP" href="" shape="circle" coords="226,639,8" />
+<area data-key="f49" title="Left Index Toe MTP " href="" shape="circle" coords="242,619,9" />
+<area data-key="f50" title="Left Index Toe PIP" href="" shape="circle" coords="247,637,8" />
+<area data-key="f51" title="Left Middle Toe MTP" href="" shape="circle" coords="264,617,9" />
+<area data-key="f52" title="Left Middle Toe PIP" href="" shape="circle" coords="268,637,8" />
+<area data-key="f53" title="Left Ring Toe MTP" href="" shape="circle" coords="283,609,8" />
+<area data-key="f54" title="Left Ring Toe PIP" href="" shape="circle" coords="287,628,9" />
+<area data-key="f55" title="Left Pinky Toe MTP" href="" shape="circle" coords="301,599,9" />
+<area data-key="f56" title="Left Pinky Toe PIP" href="" shape="circle" coords="305,617,7" />
+<area data-key="f57" title="Right Hallux MTP" href="" shape="circle" coords="183,621,8" />
+<area data-key="f58" title="Right Hallux PIP" href="" shape="circle" coords="178,640,10" />
+<area data-key="f59" title="Right Index Toe MTP" href="" shape="circle" coords="161,620,8" />
+<area data-key="f60" title="Right Index Toe PIP" href="" shape="circle" coords="157,638,9" />
+<area data-key="f61" title="Right Middle Toe MTP" href="" shape="circle" coords="140,617,8" />
+<area data-key="f62" title="Right Middle Toe PIP" href="" shape="circle" coords="136,636,7" />
+<area data-key="f63" title="Right Ring Toe MTP" href="" shape="circle" coords="121,609,9" />
+<area data-key="f64" title="Right Ring Toe PIP" href="" shape="circle" coords="117,629,9" />
+<area data-key="f65" title="Right Pinky Toe MTP" href="" shape="circle" coords="102,598,8" />
+<area data-key="f66" title="Right Pinky Toe PIP" href="" shape="circle" coords="99,619,9" />
+<area data-key="f67" title="Cervical Spine" href="" shape="poly" coords="193,79,209,79,211,108,206,112,206,118,199,117,197,110,193,106" />
+<area data-key="f68" title="Thoracic Spine" href="" shape="poly" coords="193,126,197,118,208,119,212,126,211,202,202,200,192,203" />
+<area data-key="f69" title="Lumbar Spine" href="" shape="poly" coords="194,201,202,199,211,200,211,260,202,263,194,262" />
+<area data-key="f70" title="Left Sacroiliac" href="" shape="circle" coords="221,268,9" />
+<area data-key="f71" title="Right Sacroiliac" href="" shape="circle" coords="182,268,9" />
+<area data-key="f72" title="Left Ankle" href="" shape="poly" coords="242,553,250,552,256,554,261,558,261,565,256,568,250,569,242,571,234,570,226,566,223,561,228,554,236,549" />
+<area data-key="f73" title="Right Ankle" href="" shape="poly" coords="159,553,168,553,179,558,180,567,173,571,164,574,156,574,147,571,142,566,143,558,149,554" />
+<area data-key="f74" title="Left Talonavicular" href="" shape="poly" coords="218,589,226,581,240,576,255,571,274,570,285,572,282,580,271,586,261,590,242,595,227,594" />
+<area data-key="f75" title="Right Talonavicular" href="" shape="poly" coords="119,575,130,571,141,572,153,575,171,580,183,587,186,594,175,595,159,596,145,593,131,588,124,584" />
+<area data-key="f76" title="Left Tarsometatarsal" href="" shape="poly" coords="219,607,237,599,257,593,278,587,294,585,291,593,280,600,264,605,249,608,234,610" />
+<area data-key="f77" title="Right Tarsometatarsal" href="" shape="poly" coords="110,584,124,586,135,587,148,591,162,597,174,601,182,604,188,605,174,609,160,610,147,608,133,604,124,600,116,594" />


### PR DESCRIPTION
The rheumatoid_man imagemap silently fails due to a dangling closing map tag at the end of the mapping file. This PR fixes this issue #23.